### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,24 @@
+name: 'Bug Report'
+description: File a bug report
+title: '[Bug]: '
+labels: [bug, help wanted]
+assignees: vedantmgoyal2009
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you noticed.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Bug Report
-    url: https://github.com/vedantmgoyal2009/vedantmgoyal2009/issues/new?assignees=vedantmgoyal2009&labels=bug%2Chelp+wanted&template=bug.yml&title=%5BBug%5D%3A+
-    about: File a bug report
-  - name: Feature Request
-    url: https://github.com/vedantmgoyal2009/vedantmgoyal2009/issues/new?assignees=vedantmgoyal2009&labels=feat&template=feat.yml&title=%5BFeature%2FIdea%5D%3A+
-    about: Request a new feature
+  - name: Review open issues
+    url: https://github.com/vedantmgoyal2009/winget-releaser/issues
+    about: Please ensure you have gone through open issues.

--- a/.github/ISSUE_TEMPLATE/feat.yml
+++ b/.github/ISSUE_TEMPLATE/feat.yml
@@ -1,0 +1,17 @@
+name: 'Feature Request'
+description: Request a new feature
+title: '[Feature/Idea]: '
+labels: [feat]
+assignees: vedantmgoyal2009
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to request a new feature!
+  - type: textarea
+    attributes:
+      label: What would you like to see changed/added?
+      description: Try to give some examples to make it really clear!
+      placeholder: Tell us what you would like to see! Something new and amazing!
+    validations:
+      required: true


### PR DESCRIPTION
This PR adds issue templates for this repo. They are modified from the issue templates on [vedantmgoyal2009/vedantmgoyal2009](https://github.com/vedantmgoyal2009/vedantmgoyal2009/tree/main/.github/ISSUE_TEMPLATE), with the main change being the removal of project selection on the issue.