### PR TITLE
[Bug]: add missing repo name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
   release-tag:
     required: true
     description: The release tag to be used for creating manifests.
-    default: ${{ github.release.tag_name || github.ref }}
+    default: ${{ github.release.tag_name || github.ref_name }}
   token:
     required: true
     description: GitHub token to create pull request on Windows Package Manager Community Repository.

--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,6 @@ inputs:
     required: true
     description: Whether to delete the last version.
     default: 'false'
-  release-repository:
-    required: true
-    description: The repository where the release is present (should be present under same user/organization).
-    default: ${{ github.event.repository.name }}
   release-tag:
     required: true
     description: The release tag to be used for creating manifests.

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const { resolve } = require("path");
     ...(
       await getOctokit(token).rest.repos.getReleaseByTag({
         owner: context.repo.owner,
-        repo: releaseRepository,
+        repo: context.repo.name,
         tag: releaseTag,
       })
     ).data,

--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ const { resolve } = require("path");
   const pkgid = getInput("identifier");
   const version = getInput("version");
   const instRegex = getInput("installers-regex");
-  const releaseRepository = getInput("release-repository");
   const releaseTag = getInput("release-tag");
   const delPrevVersion = getBooleanInput("delete-previous-version");
   const token = getInput("token");

--- a/index.js
+++ b/index.js
@@ -1,24 +1,24 @@
-const { getInput, info, getBooleanInput, error } = require('@actions/core');
-const { context, getOctokit } = require('@actions/github');
-const { execSync } = require('child_process');
-const { resolve } = require('path');
+const { getInput, info, getBooleanInput, error } = require("@actions/core");
+const { context, getOctokit } = require("@actions/github");
+const { execSync } = require("child_process");
+const { resolve } = require("path");
 
 (async () => {
   // check if the runner operating system is windows
-  if (process.platform != 'win32') {
-    error('This action only works on Windows.');
+  if (process.platform != "win32") {
+    error("This action only works on Windows.");
     process.exit(1);
   }
 
   // get the inputs from the action
-  const pkgid = getInput('identifier');
-  const version = getInput('version');
-  const instRegex = getInput('installers-regex');
-  const releaseRepository = getInput('release-repository');
-  const releaseTag = getInput('release-tag');
-  const delPrevVersion = getBooleanInput('delete-previous-version');
-  const token = getInput('token');
-  const forkUser = getInput('fork-user');
+  const pkgid = getInput("identifier");
+  const version = getInput("version");
+  const instRegex = getInput("installers-regex");
+  const releaseRepository = getInput("release-repository");
+  const releaseTag = getInput("release-tag");
+  const delPrevVersion = getBooleanInput("delete-previous-version");
+  const token = getInput("token");
+  const forkUser = getInput("fork-user");
 
   // get only data, and exclude status, url, and headers
   releaseInfo = {
@@ -34,55 +34,55 @@ const { resolve } = require('path');
   // install powershell-yaml, clone winget-pkgs repo and configure remotes, update yamlcreate, and
   // download wingetdev from vedantmgoyal2009/vedantmgoyal2009 (winget-pkgs-automation)
   info(
-    `::group::Install powershell-yaml, clone winget-pkgs and configure remotes, update YamlCreate, download wingetdev...`
+    `::group::Install powershell-yaml, clone winget-pkgs and configure remotes, update YamlCreate, download wingetdev...`,
   );
   execSync(
     `Install-Module -Name powershell-yaml -Repository PSGallery -Scope CurrentUser -Force`,
-    { shell: 'pwsh', stdio: 'inherit' }
+    { shell: "pwsh", stdio: "inherit" },
   );
   // remove winget-pkgs directory if it exists, in case the action is run multiple times for
   // publishing multiple packages in the same workflow
   execSync(
     `Remove-Item -Path .\\winget-pkgs\\ -Recurse -Force -ErrorAction SilentlyContinue`,
-    { shell: 'pwsh', stdio: 'inherit' }
+    { shell: "pwsh", stdio: "inherit" },
   );
   execSync(
     `git clone https://x-access-token:${token}@github.com/microsoft/winget-pkgs.git`,
     {
-      stdio: 'inherit',
-    }
+      stdio: "inherit",
+    },
   );
   execSync(
     `git -C winget-pkgs config --local user.name github-actions`,
-    { stdio: 'inherit' }
+    { stdio: "inherit" },
   );
   execSync(
     `git -C winget-pkgs config --local user.email 41898282+github-actions[bot]@users.noreply.github.com`,
-    { stdio: 'inherit' }
+    { stdio: "inherit" },
   );
   execSync(`git -C winget-pkgs remote rename origin upstream`, {
-    stdio: 'inherit',
+    stdio: "inherit",
   });
   execSync(
     `git -C winget-pkgs remote add origin https://github.com/${forkUser}/winget-pkgs.git`,
-    { stdio: 'inherit' }
+    { stdio: "inherit" },
   );
   execSync(
     // NOTE: replace latest with main, while testing the action after modifying yamlcreate.ps1
     `Invoke-WebRequest -Uri https://github.com/vedantmgoyal2009/winget-releaser/raw/latest/YamlCreate.ps1 -OutFile .\\winget-pkgs\\Tools\\YamlCreate.ps1`,
-    { shell: 'pwsh', stdio: 'inherit' }
+    { shell: "pwsh", stdio: "inherit" },
   );
   execSync(`git -C winget-pkgs commit --all -m \"Update YamlCreate.ps1\"`, {
-    stdio: 'inherit',
+    stdio: "inherit",
   });
   execSync(
     `svn checkout https://github.com/vedantmgoyal2009/vedantmgoyal2009/trunk/tools/wingetdev`,
-    { stdio: 'inherit' }
+    { stdio: "inherit" },
   );
   info(`::endgroup::`);
 
   // resolve wingetdev path
-  process.env.WINGETDEV = resolve('wingetdev', 'wingetdev.exe');
+  process.env.WINGETDEV = resolve("wingetdev", "wingetdev.exe");
 
   // set GH_TOKEN env variable for GitHub CLI (gh)
   process.env.GH_TOKEN = token;
@@ -91,11 +91,11 @@ const { resolve } = require('path');
   info(`::group::Update manifests and create pull request`);
   const inputObject = JSON.stringify({
     PackageIdentifier: pkgid,
-    PackageVersion:
-      version || new RegExp(/(?<=v).*/g).exec(releaseInfo.tag_name)[0],
+    PackageVersion: version ||
+      new RegExp(/(?<=v).*/g).exec(releaseInfo.tag_name)[0],
     InstallerUrls: releaseInfo.assets
       .filter((asset) => {
-        return new RegExp(instRegex, 'g').test(asset.name);
+        return new RegExp(instRegex, "g").test(asset.name);
       })
       .map((asset) => {
         return asset.browser_download_url;
@@ -105,9 +105,9 @@ const { resolve } = require('path');
     DeletePreviousVersion: delPrevVersion,
   });
   execSync(`.\\YamlCreate.ps1 \'${inputObject}\'`, {
-    cwd: 'winget-pkgs/Tools',
-    shell: 'pwsh',
-    stdio: 'inherit',
+    cwd: "winget-pkgs/Tools",
+    shell: "pwsh",
+    stdio: "inherit",
   });
   info(`::endgroup::`);
 })();

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ const { resolve } = require('path');
       await getOctokit(token).rest.repos.getReleaseByTag({
         owner: context.repo.owner,
         repo: releaseRepository,
-        tag: releaseTag.replace('refs/tags/', ''),
+        tag: releaseTag,
       })
     ).data,
   };
@@ -40,6 +40,12 @@ const { resolve } = require('path');
     `Install-Module -Name powershell-yaml -Repository PSGallery -Scope CurrentUser -Force`,
     { shell: 'pwsh', stdio: 'inherit' }
   );
+  // remove winget-pkgs directory if it exists, in case the action is run multiple times for
+  // publishing multiple packages in the same workflow
+  execSync(
+    `Remove-Item -Path .\\winget-pkgs\\ -Recurse -Force -ErrorAction SilentlyContinue`,
+    { shell: 'pwsh', stdio: 'inherit' }
+  );
   execSync(
     `git clone https://x-access-token:${token}@github.com/microsoft/winget-pkgs.git`,
     {
@@ -47,11 +53,11 @@ const { resolve } = require('path');
     }
   );
   execSync(
-    `git -C winget-pkgs config --local user.name ${context.payload.sender.login}`,
+    `git -C winget-pkgs config --local user.name github-actions`,
     { stdio: 'inherit' }
   );
   execSync(
-    `git -C winget-pkgs config --local user.email ${context.payload.sender.id}+${context.payload.sender.login}@users.noreply.github.com`,
+    `git -C winget-pkgs config --local user.email 41898282+github-actions[bot]@users.noreply.github.com`,
     { stdio: 'inherit' }
   );
   execSync(`git -C winget-pkgs remote rename origin upstream`, {
@@ -86,7 +92,7 @@ const { resolve } = require('path');
   const inputObject = JSON.stringify({
     PackageIdentifier: pkgid,
     PackageVersion:
-      version || new RegExp(/[0-9.]+/g).exec(releaseInfo.tag_name)[0],
+      version || new RegExp(/(?<=v).*/g).exec(releaseInfo.tag_name)[0],
     InstallerUrls: releaseInfo.assets
       .filter((asset) => {
         return new RegExp(instRegex, 'g').test(asset.name);


### PR DESCRIPTION
This fixes an issue where the [repo](https://github.com/vedantmgoyal2009/winget-releaser/blob/main/index.js#L28) name passed to getReleasedByTag is blank creating a request url of `https://api.github.com/repos/neovim//releases/tags/nightly`.

The relevant output can be found in the following links: https://github.com/neovim/neovim/actions/runs/3117155225/jobs/5055669653#step:4:15, https://github.com/neovim/neovim/actions/runs/3117155225/jobs/5055669653#step:4:56

This pull request is related to issue #24.