### PR TITLE
fix: `github.release.tag_name` -> `github.event.release.tag_name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ delete-previous-version: 'true' # don't forget to quotes
 
 ### Release tag (release-tag)
 
-- Required: ❌ (Default value: `${{ github.release.tag_name || github.ref }}`)
+- Required: ❌ (Default value: `${{ github.event.release.tag_name || github.ref }}`)
 
 The GitHub release tag of the release you want to publish to Windows Package Manager (WinGet).
 

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
   release-tag:
     required: true
     description: The release tag to be used for creating manifests.
-    default: ${{ github.release.tag_name || github.ref_name }}
+    default: ${{ github.event.release.tag_name || github.ref_name }}
   token:
     required: true
     description: GitHub token to create pull request on Windows Package Manager Community Repository.


### PR DESCRIPTION
Fix typo. I was wondering why that value wasn't working