### PR TITLE
Specify WinGet Releaser in Script Header

### DIFF
--- a/src/YamlCreate.ps1
+++ b/src/YamlCreate.ps1
@@ -8,7 +8,7 @@ Param
 )
 $ProgressPreference = 'SilentlyContinue'
 
-$ScriptHeader = '# Created with YamlCreate.ps1 v2.2.1 using InputObject 🤖'
+$ScriptHeader = '# Created with WinGet Releaser 🛫 using YamlCreate.ps1 v2.2.1'
 $ManifestVersion = '1.2.0'
 $PSDefaultParameterValues = @{ '*:Encoding' = 'UTF8' }
 $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False


### PR DESCRIPTION
This is a small PR to change the header of manifests created from WinGet Releaser, to specify that they were created with WinGet Releaser. This isn't necessary, but it would be nice to differentiate it from traditional automation as being its own tool.