### PR TITLE
feat: log command to invoke komac to stdout

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -83,7 +83,7 @@ import { existsSync, rmSync } from 'node:fs';
   process.env.KMC_FRK_OWNER = forkUser;
   process.env.GITHUB_TOKEN = token;
   const command = `$env:JAVA_HOME_17_X64\\bin\\java.exe -jar komac.jar update --id \'${pkgid}\' --version ${pkgVersion} --urls \'${installerUrls.join(',') }\' --submit`;
-  console.log(`Executing command: java -jar ${command.split('java.exe -jar ')[1]}`);
+  info(`Executing command: java -jar ${command.split('java.exe -jar ')[1]}`);
   execSync(`& ${command}`, {
     shell: 'pwsh',
     stdio: 'inherit',

--- a/main.ts
+++ b/main.ts
@@ -82,9 +82,9 @@ import { existsSync, rmSync } from 'node:fs';
   process.env.KMC_CRTD_WITH = `WinGet Releaser ${process.env.GITHUB_ACTION_REF}`;
   process.env.KMC_FRK_OWNER = forkUser;
   process.env.GITHUB_TOKEN = token;
-  const command = `& $env:JAVA_HOME_17_X64\\bin\\java.exe -jar komac.jar update --id \'${pkgid}\' --version ${pkgVersion} --urls \'${installerUrls.join(',') }\' --submit`;
-  console.log(`Executing command: ${command}`);
-  execSync(command, {
+  const command = `$env:JAVA_HOME_17_X64\\bin\\java.exe -jar komac.jar update --id \'${pkgid}\' --version ${pkgVersion} --urls \'${installerUrls.join(',') }\' --submit`;
+  console.log(`Executing command: java -jar ${command.split('java.exe -jar ')[1]}`);
+  execSync(`& ${command}`, {
     shell: 'pwsh',
     stdio: 'inherit',
   });

--- a/main.ts
+++ b/main.ts
@@ -82,15 +82,12 @@ import { existsSync, rmSync } from 'node:fs';
   process.env.KMC_CRTD_WITH = `WinGet Releaser ${process.env.GITHUB_ACTION_REF}`;
   process.env.KMC_FRK_OWNER = forkUser;
   process.env.GITHUB_TOKEN = token;
-  execSync(
-    `& $env:JAVA_HOME_17_X64\\bin\\java.exe -jar komac.jar update --id \'${pkgid}\' --version ${pkgVersion} --urls \'${installerUrls.join(
-      ',',
-    )}\' --submit`,
-    {
-      shell: 'pwsh',
-      stdio: 'inherit',
-    },
-  );
+  const command = `& $env:JAVA_HOME_17_X64\\bin\\java.exe -jar komac.jar update --id \'${pkgid}\' --version ${pkgVersion} --urls \'${installerUrls.join(',') }\' --submit`;
+  console.log(`Executing command: ${command}`);
+  execSync(command, {
+    shell: 'pwsh',
+    stdio: 'inherit',
+  });
   endGroup();
 
   // get the list of existing versions of the package using wingetdev

--- a/main.ts
+++ b/main.ts
@@ -82,9 +82,9 @@ import { existsSync, rmSync } from 'node:fs';
   process.env.KMC_CRTD_WITH = `WinGet Releaser ${process.env.GITHUB_ACTION_REF}`;
   process.env.KMC_FRK_OWNER = forkUser;
   process.env.GITHUB_TOKEN = token;
-  const command = `$env:JAVA_HOME_17_X64\\bin\\java.exe -jar komac.jar update --id \'${pkgid}\' --version ${pkgVersion} --urls \'${installerUrls.join(',') }\' --submit`;
-  info(`Executing command: java -jar ${command.split('java.exe -jar ')[1]}`);
-  execSync(`& ${command}`, {
+  const command = `-jar komac.jar update --id \'${pkgid}\' --version ${pkgVersion} --urls \'${installerUrls.join(',') }\' --submit`;
+  info(`Executing command: java ${command}`);
+  execSync(`& $env:JAVA_HOME_17_X64\\bin\\java.exe ${command}`, {
     shell: 'pwsh',
     stdio: 'inherit',
   });


### PR DESCRIPTION
To test:

```typescript
const pkgid = "Package.Identifier"
const pkgVersion = "1.2.3"
const installerUrls = ["url1", "url2"];

const command = `-jar komac.jar update --id \'${pkgid}\' --version ${pkgVersion} --urls \'${installerUrls.join(',') }\' --submit`;
console.log(`Executing command: java ${command}`);
```
Outputs:
```bash
Executing command: java -jar komac.jar update --id 'Package.Identifier' --version 1.2.3 --urls 'url1,url2' --submit
```

Resolves #119