### PR TITLE
Fix Komac command to work cross-platform

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9866,9 +9866,10 @@ const node_https_1 = __nccwpck_require__(2286);
     });
     // execute komac to update the manifest and submit the pull request
     process.env.KMC_CRTD_WITH = `WinGet Releaser ${process.env.GITHUB_ACTION_REF}`;
+    const binPath = (0, core_1.toPlatformPath)('$env:JAVA_HOME_17_X64\\bin\\java');
     const command = `-jar komac.jar update --id \'${pkgid}\' --version ${pkgVersion} --urls \'${installerUrls.join(',')}\' --submit`;
     (0, core_1.info)(`Executing command: java ${command}`);
-    (0, node_child_process_1.execSync)(`& $env:JAVA_HOME_17_X64\\bin\\java.exe ${command}`, {
+    (0, node_child_process_1.execSync)(`& ${binPath} ${command}`, {
         shell: 'pwsh',
         stdio: 'inherit',
     });
@@ -9903,7 +9904,7 @@ const node_https_1 = __nccwpck_require__(2286);
             (0, core_1.startGroup)(`Deleting version ${version}...`);
             const command = `-jar komac.jar remove --id \'${pkgid}\' --version ${pkgVersion} --reason \'This version is older than what has been set in \`max-versions-to-keep\` by the publisher.\' --submit`;
             (0, core_1.info)(`Executing command: java ${command}`);
-            (0, node_child_process_1.execSync)(`& $env:JAVA_HOME_17_X64\\bin\\java.exe ${command}`, {
+            (0, node_child_process_1.execSync)(`& ${binPath} ${command}`, {
                 shell: 'pwsh',
                 stdio: 'inherit',
             });

--- a/main.ts
+++ b/main.ts
@@ -5,6 +5,7 @@ import {
   startGroup,
   info,
   warning,
+  toPlatformPath,
 } from '@actions/core';
 import { context, getOctokit } from '@actions/github';
 import { execSync } from 'node:child_process';
@@ -83,11 +84,12 @@ import { get, request } from 'node:https';
 
   // execute komac to update the manifest and submit the pull request
   process.env.KMC_CRTD_WITH = `WinGet Releaser ${process.env.GITHUB_ACTION_REF}`;
+  const binPath = toPlatformPath('$env:JAVA_HOME_17_X64\\bin\\java');
   const command = `-jar komac.jar update --id \'${pkgid}\' --version ${pkgVersion} --urls \'${installerUrls.join(
     ',',
   )}\' --submit`;
   info(`Executing command: java ${command}`);
-  execSync(`& $env:JAVA_HOME_17_X64\\bin\\java.exe ${command}`, {
+  execSync(`& ${binPath} ${command}`, {
     shell: 'pwsh',
     stdio: 'inherit',
   });
@@ -142,7 +144,7 @@ import { get, request } from 'node:https';
       startGroup(`Deleting version ${version}...`);
       const command = `-jar komac.jar remove --id \'${pkgid}\' --version ${pkgVersion} --reason \'This version is older than what has been set in \`max-versions-to-keep\` by the publisher.\' --submit`;
       info(`Executing command: java ${command}`);
-      execSync(`& $env:JAVA_HOME_17_X64\\bin\\java.exe ${command}`, {
+      execSync(`& ${binPath} ${command}`, {
         shell: 'pwsh',
         stdio: 'inherit',
       });


### PR DESCRIPTION
Remove `.exe` extension and normalize slashes to match the runner platform.

Note: See https://github.com/vedantmgoyal2009/winget-releaser/issues/126#issuecomment-1575484185