### PR TITLE
feat: add `replace` and `release-notes-url` update options

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ jobs:
   - **Required**: ❌ (Default value: `${{ github.event.release.tag_name || github.ref_name }}`)
   - **Example**: `release-tag: ${{ inputs.version }} # workflow_dispatch input 'version'`
 
+- `release-notes-url`: URL to package version's release notes.
+
+  - **Required**: ❌ (Default value: GitHub release page)
+  - **Example**: `release-notes-url: https://example.com/release-notes/${{ github.event.release.tag_name }}`
+
 - `token`: The GitHub token with which the action will authenticate with GitHub API and create a pull request on the [WinGet Community Repository][winget-pkgs-repo]. **The token should have a `public_repo` scope.**
 
   - **Required**: ✅

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
     required: true
     description: The release tag to be used for creating manifests.
     default: ${{ github.event.release.tag_name || github.ref_name }}
+  release-notes-url:
+    required: false
+    description: Package version's release notes URL. Defaults to GitHub release page.
   token:
     required: true
     description: GitHub token to create pull request on Windows Package Manager Community Repository.
@@ -79,7 +82,17 @@ runs:
         KOMAC_FORK_OWNER: ${{ inputs.fork-user }}
         GITHUB_TOKEN: ${{ inputs.token }}
       shell: pwsh
-    - run: komac update '${{ inputs.identifier }}' --version '${{ steps.version-and-urls.outputs.version }}' --submit --urls ${{ steps.version-and-urls.outputs.urls }}
+    - run: |
+        $ReplaceFlag = ""
+        $ReleaseNotesUrlFlag = ""
+        if (${{ inputs.max-versions-to-keep }} -eq 1) {
+          $ReplaceFlag = "--replace"
+        }
+        if (-not [string]::IsNullOrEmpty('${{ inputs.release-notes-url }}')) {
+          $ReleaseNotesUrlFlag = "--replace-notes-url '${{ inputs.release-notes-url }}'"
+        }
+
+        komac update '${{ inputs.identifier }}' --version '${{ steps.version-and-urls.outputs.version }}' $ReplaceFlag  $ReleaseNotesUrlFlag --submit --urls ${{ steps.version-and-urls.outputs.urls }}
       env:
         KOMAC_FORK_OWNER: ${{ inputs.fork-user }}
         KOMAC_CREATED_WITH: WinGet Releaser
@@ -98,6 +111,11 @@ runs:
         #[Issue #307] -NoEnumerate has been added so that $Versions does not get converted to a string, when only one version exists in winget-pkgs
         $Versions = komac list-versions '${{ inputs.identifier }}' --json | ConvertFrom-Json -NoEnumerate | Sort-Object $ToNatural -Descending
         $Reason = 'This version is older than what has been set in `max-versions-to-keep` by the publisher.'
+
+        # Prevents replaced version from being deleted
+        if (${{ inputs.max-versions-to-keep }} -eq 1) {
+          $Versions = $Versions | Select-Object -SkipLast 1
+        }
 
         If ($Versions.Count + 1 -gt ${{ inputs.max-versions-to-keep }}) {
           $VersionsToDelete = $Versions[(${{ inputs.max-versions-to-keep }} - 1)..($Versions.Count - 1)]

--- a/action.yml
+++ b/action.yml
@@ -4,35 +4,26 @@ author: vedantmgoyal9 (Vedant)
 inputs:
   identifier:
     required: true
-    description: The PackageIdentifier of the package (case-sensitive).
   version:
     required: false
-    description: The PackageVersion of the package you want to release.
   installers-regex:
     required: true
-    description: The regex to match the installers.
     default: '.(exe|msi|msix|appx)(bundle){0,1}$'
   max-versions-to-keep:
     required: true
-    description: 'The maximum number of versions to keep in WinGet Community Repository (Default: 0 - no limit)'
     default: '0'
   release-repository:
     required: true
-    description: The repository where the release is present (should be present under same user/organization).
     default: ${{ github.event.repository.name }}
   release-tag:
     required: true
-    description: The release tag to be used for creating manifests.
     default: ${{ github.event.release.tag_name || github.ref_name }}
   release-notes-url:
     required: false
-    description: Package version's release notes URL. Defaults to GitHub release page.
   token:
     required: true
-    description: GitHub token to create pull request on Windows Package Manager Community Repository.
   fork-user:
     required: true
-    description: GitHub username where the fork of winget-pkgs is present.
     default: ${{ github.repository_owner }}
 runs:
   using: composite


### PR DESCRIPTION
### Pull Request Checklist

- [x] The commit message(s) follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines.

### Changes & Notes
- Adds a option to specify a release notes URL.
- Packages which have `max-versions-to-keep`  set to 1 will be replaced. This will open 1 PR to replace the current version with the latest instead of opening 2 separate PRs.